### PR TITLE
Use the correct line endings for the current platform

### DIFF
--- a/lib/new-post-view.coffee
+++ b/lib/new-post-view.coffee
@@ -1,6 +1,7 @@
 {View, EditorView} = require 'atom'
 path = require 'path'
 fs = require 'fs-plus'
+os = require 'os'
 
 module.exports =
 class JekyllNewPostView extends View
@@ -63,5 +64,11 @@ class JekyllNewPostView extends View
     catch error
       @showError("#{error.message}.")
 
-  fileContents:(title, dateString)->
-    return '---\r\nlayout: post\r\ntitle: "' + title + '"\r\ndate: ' + dateString + '\r\n---'
+  fileContents: (title, dateString) ->
+    [
+      '---'
+      'layout: post'
+      "title: \"#{title}\""
+      "date: \"#{dateString}\""
+      '---'
+    ].join(os.EOL)


### PR DESCRIPTION
This package is quite handy, but I noticed that new posts are always created with Windows-style CRLF line endings, rather than ones that are native to the current platform. This uses Node's [`os.EOL`](http://nodejs.org/docs/v0.11.10/api/os.html#os_os_eol) to generate the new post template with the proper line endings.

By the way, while I was looking for the best way to do this, I noticed that `TextBuffer` in Atom core seems to always use `\n`. If you'd prefer being consistent with that instead it would be an even more trivial change - I could change it to a [CoffeeScript multi-line string literal](http://coffeescript.org/#strings) and not have to do the `.join` stuff.
