### PR TITLE
Conform to styleguide better, dark UI expecially

### DIFF
--- a/lib/manage-view.coffee
+++ b/lib/manage-view.coffee
@@ -22,8 +22,8 @@ class ManagerView extends ScrollView
           @div class: 'jekyll-version', outlet: "jekyllVersion"
           @div class: 'pwd', outlet: "jekyllPWD"
           @div class: 'server-status', outlet: "serverStatus", "Server Status: ", =>
-            @span class: 'off', "Off"
-        @div class: 'console', outlet: "console"
+            @span class: 'highlight-error', "Off"
+        @pre class: 'console', outlet: "console"
 
   getTitle: ->
     'Jekyll Manager'
@@ -51,8 +51,8 @@ class ManagerView extends ScrollView
 
     @startServer.on 'click', ->
       $('.server-status span').html("Running")
-      $('.server-status span').addClass("on")
-      $('.server-status span').removeClass("off")
+      $('.server-status span').addClass("highlight-success")
+      $('.server-status span').removeClass("highlight-error")
 
       $('.console').append("Launching Server... <i>(" + atom.config.get('jekyll.jekyllBinary') + " " + atom.config.get('jekyll.serverOptions').join(" ") + ")</i><br />")
 
@@ -64,8 +64,8 @@ class ManagerView extends ScrollView
 
     @stopServer.on 'click', ->
       $('.server-status span').html("Off")
-      $('.server-status span').addClass("off")
-      $('.server-status span').removeClass("on")
+      $('.server-status span').addClass("highlight-error")
+      $('.server-status span').removeClass("highlight-success")
 
       killCMD = "kill " + ManagerView.server.pid
       $('.console').append("Stopping Server... <i>(" + killCMD + ")</i><br />")

--- a/stylesheets/manage-view.less
+++ b/stylesheets/manage-view.less
@@ -3,7 +3,6 @@
     width:20%;
     height:100%;
     box-shadow: -1px 0px 1px -1px #aeaeae inset;
-    background-color: #e7e7e7;
     float:left;
 
     .jekyll-logo{
@@ -56,23 +55,13 @@
         span{
           float:right;
         }
-
-        .on{
-          color:#0f0;
-        }
-
-        .off{
-          color:#f00;
-        }
       }
     }
 
     .console{
-      background-color:#000;
       height:100%;
       width:100%;
       display:block;
-      color:#fff;
       box-sizing:border-box;
       padding:10px;
       overflow-y:scroll;


### PR DESCRIPTION
Making some use of default classes for the manager view to play nice with most UI themes out there. It was barely usable on some dark UIs like _Ekini Like_ because of the custom colors in CSS.

And I've also took the opportunity to change console's `div` into `pre` to get a monospaced font for consistency.

Here's how it looks now in the dark:

![Screenshot](http://i.imgur.com/fS0Psyp.png)

...and seems fine in the light too:

![Screenshot](http://i.imgur.com/7VYlUMx.png)

You might want to look at the styleguide (`Ctrl+Shift+G` in Atom), it contains lots of themeable UI goodness.
