### PR TITLE
Add Timezone in Date String Generator

### DIFF
--- a/lib/jekyll/utils.coffee
+++ b/lib/jekyll/utils.coffee
@@ -50,6 +50,12 @@ module.exports =
       ":" +
       ("0" + currentTime.getSeconds()).slice(-2)
 
+      timezoneOffset = currentTime.getTimezoneOffset()
+      string += " " +
+      (if timezoneOffset <= 0 then "+" else "-") +
+      ("0" + Math.floor(Math.abs(timezoneOffset) / 60)).slice(-2) +
+      ("0" + Math.abs(timezoneOffset) % 60).slice(-2)
+
     return string
 
   scan: (string, pattern) ->


### PR DESCRIPTION
When creating new post, the date in the front matter was set as user local time without timezone info. This may cause some problems when building or in post metadata.

If the build server and the user are not in the same timezone, e.g. the user in UTC+10 and the build server in UTC, the date will always be ahead of the build server. Since Jekyll won't build posts with a future date unless with `--future`, the post will be hidden until another build 10 hours later.